### PR TITLE
feat: Add highlight for React prop names

### DIFF
--- a/lua/darcula.lua
+++ b/lua/darcula.lua
@@ -196,6 +196,8 @@ M.configure_highlights = function()
     hi(0, "@lsp.typemod.variable.defaultLibrary", { link = "TSKeyword" })
     hi(0, "@lsp.mod.defaultLibrary.go", { link = "TSKeyword" })
     hi(0, "@lsp.type.property", { link = "TSField" })
+    hi(0, "@tag.attribute.tsx", { link = "TSParameter" })
+    hi(0, "@tag.attribute.javascript", { link = "TSParameter" })
   end
 
   hi(0, "Bold", { bold = true })


### PR DESCRIPTION
Add highlight group for JSX/TSX props names to distinguish them easily

Before:
<img width="470" alt="Screenshot 2024-12-10 at 15 40 02" src="https://github.com/user-attachments/assets/845e51da-35af-43ab-af65-923a9dc35ed1">

After:
<img width="481" alt="Screenshot 2024-12-10 at 15 33 05" src="https://github.com/user-attachments/assets/771fee3f-57f5-4607-a73a-c6739857e4bc">

First time actually tweaking neovim theme, so if anything needs to be changed - let me know.